### PR TITLE
feat: query builder

### DIFF
--- a/dev/mssql/2019/docker-compose.yml
+++ b/dev/mssql/2019/docker-compose.yml
@@ -5,10 +5,11 @@ services:
     environment:
       ACCEPT_EULA: Y
       SA_PASSWORD: Password12!
+      MSSQL_SA_PASSWORD: Password12!
     ports:
       - 22019:1433
     healthcheck:
-      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost", "-U", "SA", "-P", "Password12!", "-l", "30", "-Q", "SELECT 1"]
+      test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-S", "localhost", "-U", "SA", "-P", "Password12!", "-l", "30", "-Q", "SELECT 1", "-C"]
       interval: 3s
       timeout: 1s
       retries: 10

--- a/dev/mssql/2019/start.sh
+++ b/dev/mssql/2019/start.sh
@@ -9,7 +9,7 @@ docker compose -p sequelize-mssql-2019 up -d
 ./../../wait-until-healthy.sh sequelize-mssql-2019
 
 docker exec sequelize-mssql-2019 \
-  /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
+  /opt/mssql-tools18/bin/sqlcmd -S localhost -U SA -P "Password12!" -C -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
 
 DIALECT=mssql node check.js
 

--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -1709,6 +1709,8 @@ https://github.com/sequelize/sequelize/discussions/15694`);
     //through
     if (include.through) {
       joinQuery = this.generateThroughJoin(include, includeAs, parentTableName.internalAs, topLevelInfo);
+    } else if (include._isCustomJoin) {
+      joinQuery = this.generateCustomJoin(include, includeAs, topLevelInfo);
     } else {
       this._generateSubQueryFilter(include, includeAs, topLevelInfo);
       joinQuery = this.generateJoin(include, topLevelInfo);
@@ -1805,6 +1807,48 @@ https://github.com/sequelize/sequelize/discussions/15694`);
       }
     }
     return null;
+  }
+
+  generateCustomJoin(include, includeAs, topLevelInfo) {
+    const right = include.model;
+    const tableRight = right.getTableName();
+    const asRight = includeAs.internalAs;
+    let joinCondition;
+    let joinWhere;
+
+    if (!include.on) throw new Error('Custom joins require an "on" condition to be specified');
+    
+    // Handle the custom join condition
+    joinCondition = this.whereItemsQuery(include.on, {
+      prefix: this.sequelize.literal(this.quoteIdentifier(asRight)),
+      model: include.model
+    });
+
+    if (include.where) {
+      joinWhere = this.whereItemsQuery(include.where, {
+        prefix: this.sequelize.literal(this.quoteIdentifier(asRight)),
+        model: include.model
+      });
+      if (joinWhere) {
+        if (include.or) {
+          joinCondition += ` OR ${joinWhere}`;
+        } else {
+          joinCondition += ` AND ${joinWhere}`;
+        }
+      }
+    }
+
+    this.aliasAs(asRight, topLevelInfo);
+
+    return {
+      join: include.required ? 'INNER JOIN' : include.right && this._dialect.supports['RIGHT JOIN'] ? 'RIGHT OUTER JOIN' : 'LEFT OUTER JOIN',
+      body: this.quoteTable(tableRight, asRight),
+      condition: joinCondition,
+      attributes: {
+        main: [],
+        subQuery: []
+      }
+    };
   }
 
   generateJoin(include, topLevelInfo) {

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -9,6 +9,7 @@ import { Sequelize, SyncOptions } from './sequelize';
 import { Col, Fn, Literal, Where, MakeNullishOptional, AnyFunction, Cast, Json } from './utils';
 import { LOCK, Transaction, Op, Optional } from './index';
 import { SetRequired } from './utils/set-required';
+import { QueryBuilder } from './query-builder';
 
 // Backport of https://github.com/sequelize/sequelize/blob/a68b439fb3ea748d3f3d37356d9fe610f86184f6/src/utils/index.ts#L85
 export type AllowReadonlyArray<T> = T | readonly T[];
@@ -2124,6 +2125,22 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
     scope: (...args: readonly any[]) => FindOptions<Attributes<M>>,
     options?: AddScopeOptions
   ): void;
+
+  /**
+   * [EXPERIMENTAL] Creates a new QueryBuilder instance for this model.
+   * This enables functional/chainable query building.
+   *
+   * @returns A new QueryBuilder instance for this model
+   *
+   * @example
+   * ```js
+   * const query = User.select()
+   *   .attributes(['name', 'email'])
+   *   .where({ active: true })
+   *   .getQuery();
+   * ```
+   */
+  static select<M extends Model>(this: ModelStatic<M>): QueryBuilder<M>;
 
   /**
    * Search for multiple instances.

--- a/src/model.js
+++ b/src/model.js
@@ -18,6 +18,7 @@ const Hooks = require('./hooks');
 const associationsMixin = require('./associations/mixin');
 const Op = require('./operators');
 const { noDoubleNestedGroup } = require('./utils/deprecations');
+const QueryBuilder = require('./query-builder');
 
 
 // This list will quickly become dated, but failing to maintain this list just means
@@ -1532,6 +1533,10 @@ class Model {
     } else {
       this.options.scopes[name] = scope;
     }
+  }
+
+  static select() {
+    return new QueryBuilder(this).select();
   }
 
   /**

--- a/src/query-builder.d.ts
+++ b/src/query-builder.d.ts
@@ -5,7 +5,7 @@ export class QueryBuilder<M extends Model = Model> {
   private _attributes: FindAttributeOptions | undefined;
   private _where: WhereOptions | undefined;
   private _group: GroupOption | undefined;
-  private _having: Literal | undefined;
+  private _having: Literal[] | undefined;
   private _order: Order | undefined;
   private _limit: number | undefined;
   private _offset: number | undefined;

--- a/src/query-builder.d.ts
+++ b/src/query-builder.d.ts
@@ -1,4 +1,4 @@
-import { FindAttributeOptions, Model, ModelStatic, Sequelize, WhereOptions } from "src";
+import { FindAttributeOptions, Model, ModelStatic, Sequelize, WhereOptions } from ".";
 
 export class QueryBuilder<M extends Model = Model> {
   _attributes: string[];

--- a/src/query-builder.d.ts
+++ b/src/query-builder.d.ts
@@ -1,0 +1,24 @@
+import { FindAttributeOptions, Model, ModelStatic, Sequelize, WhereOptions } from "src";
+
+export class QueryBuilder<M extends Model = Model> {
+  _attributes: string[];
+  _where: Record<string, any>;
+  _limit: number | null;
+  _offset: number | null;
+  _isSelect: boolean;
+  _model: M;
+  _sequelize: Sequelize;
+
+  constructor(model?: M);
+  clone(): QueryBuilder<M>;
+  select(): QueryBuilder<M>;
+  attributes(attributes: FindAttributeOptions): QueryBuilder<M>;
+  where(conditions: WhereOptions): QueryBuilder<M>;
+  limit(limit: number): QueryBuilder<M>;
+  offset(offset: number): QueryBuilder<M>;
+  getQuery(): string;
+  execute(): Promise<[unknown[], unknown]>;
+  get tableName(): string;
+  get model(): ModelStatic<M>;
+}
+

--- a/src/query-builder.d.ts
+++ b/src/query-builder.d.ts
@@ -1,9 +1,11 @@
 import { FindAttributeOptions, GroupOption, Model, ModelStatic, Order, Sequelize, WhereOptions } from '.';
+import { Literal } from './utils';
 
 export class QueryBuilder<M extends Model = Model> {
   private _attributes: FindAttributeOptions | undefined;
   private _where: WhereOptions | undefined;
   private _group: GroupOption | undefined;
+  private _having: Literal | undefined;
   private _order: Order | undefined;
   private _limit: number | undefined;
   private _offset: number | undefined;
@@ -17,6 +19,8 @@ export class QueryBuilder<M extends Model = Model> {
   attributes(attributes: FindAttributeOptions): QueryBuilder<M>;
   where(conditions: WhereOptions): QueryBuilder<M>;
   groupBy(group: GroupOption): QueryBuilder<M>;
+  having(having: Literal): QueryBuilder<M>;
+  andHaving(having: Literal): QueryBuilder<M>;
   orderBy(order: Order | undefined): QueryBuilder<M>;
   limit(limit: number): QueryBuilder<M>;
   offset(offset: number): QueryBuilder<M>;

--- a/src/query-builder.d.ts
+++ b/src/query-builder.d.ts
@@ -1,5 +1,27 @@
-import { FindAttributeOptions, GroupOption, Model, ModelStatic, Order, Sequelize, WhereOptions } from '.';
-import { Literal } from './utils';
+import {
+  FindAttributeOptions,
+  GroupOption,
+  Model,
+  ModelStatic,
+  Order,
+  Sequelize,
+  WhereOptions,
+} from ".";
+import { Col, Literal } from "./utils";
+
+type QueryBuilderIncludeOptions<M extends Model> = {
+  model: ModelStatic<M>;
+  as?: string;
+  on?: Record<keyof M, Col>;
+  attributes?: FindAttributeOptions;
+  where?: WhereOptions;
+  required?: boolean;
+  joinType?: "LEFT" | "INNER" | "RIGHT";
+};
+
+type QueryBuilderGetQueryOptions = {
+  multiline?: boolean;
+};
 
 export class QueryBuilder<M extends Model = Model> {
   private _attributes: FindAttributeOptions | undefined;
@@ -18,15 +40,15 @@ export class QueryBuilder<M extends Model = Model> {
   select(): QueryBuilder<M>;
   attributes(attributes: FindAttributeOptions): QueryBuilder<M>;
   where(conditions: WhereOptions): QueryBuilder<M>;
+  includes(options: QueryBuilderIncludeOptions<M>): QueryBuilder<M>;
   groupBy(group: GroupOption): QueryBuilder<M>;
   having(having: Literal): QueryBuilder<M>;
   andHaving(having: Literal): QueryBuilder<M>;
   orderBy(order: Order | undefined): QueryBuilder<M>;
   limit(limit: number): QueryBuilder<M>;
   offset(offset: number): QueryBuilder<M>;
-  getQuery(): string;
+  getQuery(options?: QueryBuilderGetQueryOptions): string;
   execute(): Promise<[unknown[], unknown]>;
   get tableName(): string;
   get model(): ModelStatic<M>;
 }
-

--- a/src/query-builder.d.ts
+++ b/src/query-builder.d.ts
@@ -1,10 +1,11 @@
-import { FindAttributeOptions, Model, ModelStatic, Sequelize, WhereOptions } from ".";
+import { FindAttributeOptions, Model, ModelStatic, Order, Sequelize, WhereOptions } from '.';
 
 export class QueryBuilder<M extends Model = Model> {
-  _attributes: string[];
-  _where: Record<string, any>;
-  _limit: number | null;
-  _offset: number | null;
+  _attributes: FindAttributeOptions | undefined;
+  _where: WhereOptions | undefined;
+  _order: Order | undefined;
+  _limit: number | undefined;
+  _offset: number | undefined;
   _isSelect: boolean;
   _model: M;
   _sequelize: Sequelize;
@@ -14,6 +15,7 @@ export class QueryBuilder<M extends Model = Model> {
   select(): QueryBuilder<M>;
   attributes(attributes: FindAttributeOptions): QueryBuilder<M>;
   where(conditions: WhereOptions): QueryBuilder<M>;
+  orderBy(order: Order | undefined): QueryBuilder<M>;
   limit(limit: number): QueryBuilder<M>;
   offset(offset: number): QueryBuilder<M>;
   getQuery(): string;

--- a/src/query-builder.d.ts
+++ b/src/query-builder.d.ts
@@ -1,20 +1,22 @@
-import { FindAttributeOptions, Model, ModelStatic, Order, Sequelize, WhereOptions } from '.';
+import { FindAttributeOptions, GroupOption, Model, ModelStatic, Order, Sequelize, WhereOptions } from '.';
 
 export class QueryBuilder<M extends Model = Model> {
-  _attributes: FindAttributeOptions | undefined;
-  _where: WhereOptions | undefined;
-  _order: Order | undefined;
-  _limit: number | undefined;
-  _offset: number | undefined;
-  _isSelect: boolean;
-  _model: M;
-  _sequelize: Sequelize;
+  private _attributes: FindAttributeOptions | undefined;
+  private _where: WhereOptions | undefined;
+  private _group: GroupOption | undefined;
+  private _order: Order | undefined;
+  private _limit: number | undefined;
+  private _offset: number | undefined;
+  private _isSelect: boolean;
+  private _model: M;
+  private _sequelize: Sequelize;
 
   constructor(model?: M);
   clone(): QueryBuilder<M>;
   select(): QueryBuilder<M>;
   attributes(attributes: FindAttributeOptions): QueryBuilder<M>;
   where(conditions: WhereOptions): QueryBuilder<M>;
+  groupBy(group: GroupOption): QueryBuilder<M>;
   orderBy(order: Order | undefined): QueryBuilder<M>;
   limit(limit: number): QueryBuilder<M>;
   offset(offset: number): QueryBuilder<M>;

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -1,14 +1,17 @@
 class QueryBuilder {
-  /** @type {string[]} */
+  /** @type {import('.').FindAttributeOptions | undefined} */
   _attributes;
 
-  /** @type {Record<string, any>} */
+  /** @type {import('.').WhereOptions | undefined} */
   _where;
 
-  /** @type {number | null} */
+  /** @type {import('.').Order | undefined} */
+  _order;
+
+  /** @type {number | undefined} */
   _limit;
 
-  /** @type {number | null} */
+  /** @type {number | undefined} */
   _offset;
 
   /** @type {import('./model').Model} */
@@ -32,9 +35,11 @@ class QueryBuilder {
    */
   clone() {
     const newBuilder = new QueryBuilder(this._model);
+    newBuilder._sequelize = this._sequelize;
     newBuilder._isSelect = this._isSelect;
     newBuilder._attributes = this._attributes;
     newBuilder._where = this._where;
+    newBuilder._order = this._order;
     newBuilder._limit = this._limit;
     newBuilder._offset = this._offset;
 
@@ -79,6 +84,13 @@ class QueryBuilder {
     return newBuilder;
   }
 
+  orderBy(order) {
+    const newBuilder = this.clone();
+    newBuilder._order = order;
+
+    return newBuilder;
+  }
+
   /**
    * Set a LIMIT clause on the query
    *
@@ -119,9 +131,11 @@ class QueryBuilder {
     const tableName = this._model.tableName;
 
     // Build the options object that matches Sequelize's FindOptions pattern
+    /** @type {import('.').FindOptions} */
     const options = {
       attributes: this._attributes,
       where: this._where,
+      order: this._order,
       limit: this._limit,
       offset: this._offset,
       raw: true,

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -246,7 +246,7 @@ class QueryBuilder {
     const sql = queryGenerator.selectQuery(tableName, options, this._model);
 
     if (multiline) {
-      return sql.replace(/FROM|LEFT|INNER|RIGHT|WHERE/g, '\n$&');
+      return sql.replace(/FROM|LEFT|INNER|RIGHT|WHERE|GROUP|HAVING|ORDER/g, '\n$&');
     }
 
     return sql;

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -1,0 +1,150 @@
+class QueryBuilder {
+  /** @type {string[]} */
+  _attributes;
+
+  /** @type {Record<string, any>} */
+  _where;
+
+  /** @type {number | null} */
+  _limit;
+
+  /** @type {number | null} */
+  _offset;
+
+  /** @type {import('./model').Model} */
+  _model;
+  
+  /** @type {import('./sequelize').Sequelize} */
+  _sequelize;
+  
+  /** @type {boolean} */
+  _isSelect = false;
+
+  constructor(model) {
+    this._model = model;
+    this._sequelize = model.sequelize;
+  }
+
+  /**
+   * Creates a clone of the current query builder instance with all properties copied over
+   *
+   * @returns {QueryBuilder} A new QueryBuilder instance with the same properties
+   */
+  clone() {
+    const newBuilder = new QueryBuilder(this._model);
+    newBuilder._isSelect = this._isSelect;
+    newBuilder._attributes = this._attributes;
+    newBuilder._where = this._where;
+    newBuilder._limit = this._limit;
+    newBuilder._offset = this._offset;
+
+    return newBuilder;
+  }
+
+  /**
+   * Initialize a SELECT query
+   *
+   * @returns {QueryBuilder} The query builder instance for chaining
+   */
+  select() {
+    const newBuilder = new QueryBuilder(this._model);
+    newBuilder._isSelect = true;
+
+    return newBuilder;
+  }
+
+  /**
+   * Specify which attributes to select
+   *
+   * @param {import('.').FindAttributeOptions} attributes - Array of attribute names or attribute options
+   * @returns {QueryBuilder} The query builder instance for chaining
+   */
+  attributes(attributes) {
+    const newBuilder = this.clone();
+    newBuilder._attributes = attributes;
+
+    return newBuilder;
+  }
+
+  /**
+   * Add WHERE conditions to the query
+   *
+   * @param {import('.').WhereOptions} conditions - Where conditions object
+   * @returns {QueryBuilder} The query builder instance for chaining
+   */
+  where(conditions) {
+    const newBuilder = this.clone();
+    newBuilder._where = conditions;
+
+    return newBuilder;
+  }
+
+  /**
+   * Set a LIMIT clause on the query
+   *
+   * @param {number} limit - Maximum number of rows to return
+   * @returns {QueryBuilder} The query builder instance for chaining
+   */
+  limit(limit) {
+    const newBuilder = this.clone();
+    newBuilder._limit = limit;
+
+    return newBuilder;
+  }
+
+  /**
+   * Set an OFFSET clause on the query
+   *
+   * @param {number} offset - Number of rows to skip
+   * @returns {QueryBuilder} The query builder instance for chaining
+   */
+  offset(offset) {
+    const newBuilder = this.clone();
+    newBuilder._offset = offset;
+
+    return newBuilder;
+  }
+
+  /**
+   * Generate the SQL query string
+   *
+   * @returns {string} The SQL query
+   */
+  getQuery() {
+    if (!this._isSelect) {
+      throw new Error('Query builder requires select() to be called first');
+    }
+
+    const queryGenerator = this._model.queryGenerator;
+    const tableName = this._model.tableName;
+
+    // Build the options object that matches Sequelize's FindOptions pattern
+    const options = {
+      attributes: this._attributes,
+      where: this._where,
+      limit: this._limit,
+      offset: this._offset,
+      raw: true,
+      plain: false,
+      model: this._model
+    };
+
+    // Generate the SQL using the existing query generator
+    const sql = queryGenerator.selectQuery(tableName, options, this._model);
+
+    return sql;
+  }
+
+  /**
+   * Executes the raw query
+   *
+   * @returns {Promise<[unknown[], unknown]>} The result of the query
+   */
+  async execute() {
+    const sql = this.getQuery();
+
+    return this._sequelize.query(sql);
+  }
+}
+
+module.exports = QueryBuilder;

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -1,3 +1,5 @@
+const Op = require('./operators');
+
 class QueryBuilder {
   /** @type {import('.').FindAttributeOptions | undefined} */
   _attributes;
@@ -7,6 +9,9 @@ class QueryBuilder {
 
   /** @type {import('.').GroupOption | undefined} */
   _group;
+
+  /** @type {import('./utils').Literal | undefined} */
+  _having;
 
   /** @type {import('.').Order | undefined} */
   _order;
@@ -42,6 +47,7 @@ class QueryBuilder {
     newBuilder._isSelect = this._isSelect;
     newBuilder._attributes = this._attributes;
     newBuilder._group = this._group;
+    newBuilder._having = this._having;
     newBuilder._where = this._where;
     newBuilder._order = this._order;
     newBuilder._limit = this._limit;
@@ -89,7 +95,7 @@ class QueryBuilder {
   }
 
   /**
-   * Groups the results by a specific attribute or attributes
+   * Sets the GROUP BY clause for the query
    * 
    * @param {import('.').GroupOption} group 
    * @returns {QueryBuilder} The query builder instance for chaining
@@ -97,6 +103,32 @@ class QueryBuilder {
   groupBy(group) {
     const newBuilder = this.clone();
     newBuilder._group = group;
+
+    return newBuilder;
+  }
+
+  /**
+   * Sets the HAVING clause for the query (supports only Literal condition)
+   * 
+   * @param {import('./utils').Literal} having
+   * @returns {QueryBuilder} The query builder instance for chaining
+   */
+  having(having) {
+    const newBuilder = this.clone();
+    newBuilder._having = [having];
+
+    return newBuilder;
+  }
+
+  /**
+   * Allows chaining of additional HAVING conditions
+   * 
+   * @param {import('./utils').Literal} having
+   * @returns {QueryBuilder} The query builder instance for chaining
+   */
+  andHaving(having) {
+    const newBuilder = this.clone();
+    newBuilder._having = [...newBuilder._having || [], having];
 
     return newBuilder;
   }
@@ -171,6 +203,9 @@ class QueryBuilder {
       limit: this._limit,
       offset: this._offset,
       group: this._group,
+      having: this._having && this._having.length > 0 ? {
+        [Op.and]: this._having || []
+      } : undefined,
       raw: true,
       plain: false,
       model: this._model

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -1,6 +1,7 @@
+/* eslint-disable semi */
 class QueryBuilder {
   /** @type {import('.').FindAttributeOptions | undefined} */
-  _attributes;
+  _attributes
 
   /** @type {import('.').WhereOptions | undefined} */
   _where;

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -1,36 +1,6 @@
 const Op = require('./operators');
 
 class QueryBuilder {
-  /** @type {import('.').FindAttributeOptions | undefined} */
-  _attributes;
-
-  /** @type {import('.').WhereOptions | undefined} */
-  _where;
-
-  /** @type {import('.').GroupOption | undefined} */
-  _group;
-
-  /** @type {import('./utils').Literal | undefined} */
-  _having;
-
-  /** @type {import('.').Order | undefined} */
-  _order;
-
-  /** @type {number | undefined} */
-  _limit;
-
-  /** @type {number | undefined} */
-  _offset;
-
-  /** @type {import('./model').Model} */
-  _model;
-  
-  /** @type {import('./sequelize').Sequelize} */
-  _sequelize;
-  
-  /** @type {boolean} */
-  _isSelect = false;
-
   constructor(model) {
     this._model = model;
     this._sequelize = model.sequelize;

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -1,7 +1,6 @@
-/* eslint-disable semi */
 class QueryBuilder {
   /** @type {import('.').FindAttributeOptions | undefined} */
-  _attributes
+  _attributes;
 
   /** @type {import('.').WhereOptions | undefined} */
   _where;

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -5,6 +5,9 @@ class QueryBuilder {
   /** @type {import('.').WhereOptions | undefined} */
   _where;
 
+  /** @type {import('.').GroupOption | undefined} */
+  _group;
+
   /** @type {import('.').Order | undefined} */
   _order;
 
@@ -38,6 +41,7 @@ class QueryBuilder {
     newBuilder._sequelize = this._sequelize;
     newBuilder._isSelect = this._isSelect;
     newBuilder._attributes = this._attributes;
+    newBuilder._group = this._group;
     newBuilder._where = this._where;
     newBuilder._order = this._order;
     newBuilder._limit = this._limit;
@@ -84,8 +88,36 @@ class QueryBuilder {
     return newBuilder;
   }
 
+  /**
+   * Groups the results by a specific attribute or attributes
+   * 
+   * @param {import('.').GroupOption} group 
+   * @returns {QueryBuilder} The query builder instance for chaining
+   */
+  groupBy(group) {
+    const newBuilder = this.clone();
+    newBuilder._group = group;
+
+    return newBuilder;
+  }
+
+  /**
+   * Set the ORDER BY clause for the query
+   * 
+   * @param {import('.').Order} order - The order to apply to the query
+   * @returns {QueryBuilder} The query builder instance for chaining
+   */
   orderBy(order) {
     const newBuilder = this.clone();
+    order.forEach((item, idx) => {
+      if (Array.isArray(item)) {
+        if (typeof item[0] === 'number') {
+          order[idx][0] = this._sequelize.literal(item[0]);
+        }
+      } else if (typeof item === 'number') {
+        order[idx] = this._sequelize.literal(item);
+      }
+    });
     newBuilder._order = order;
 
     return newBuilder;
@@ -138,6 +170,7 @@ class QueryBuilder {
       order: this._order,
       limit: this._limit,
       offset: this._offset,
+      group: this._group,
       raw: true,
       plain: false,
       model: this._model

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -163,6 +163,10 @@ class QueryBuilder {
       throw new Error('Model is required for includes');
     }
 
+    if (!options.on) {
+      throw new Error('Custom joins require an "on" condition to be specified');
+    }
+
     const newBuilder = this.clone();
 
     const includeOptions = {
@@ -209,7 +213,7 @@ class QueryBuilder {
           return {
             ...include,
             duplicating: false,
-            association: null, // No association for custom joins
+            association: { source: this._model }, // No association for custom joins
             parent: {
               model: this._model,
               as: this._model.name
@@ -242,7 +246,7 @@ class QueryBuilder {
     const sql = queryGenerator.selectQuery(tableName, options, this._model);
 
     if (multiline) {
-      return sql.replace(/FROM|LEFT|INNER|RIGHT|WHERE/g, '\n$1');
+      return sql.replace(/FROM|LEFT|INNER|RIGHT|WHERE/g, '\n$&');
     }
 
     return sql;

--- a/test/integration/query-builder.test.js
+++ b/test/integration/query-builder.test.js
@@ -6,6 +6,7 @@ const Support = require('../support');
 const expectsql = Support.expectsql;
 
 describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
+  /** @type {typeof import('../../src/model').Model} */
   let User;
   before(async function() {
     User = this.sequelize.define('User', {
@@ -74,6 +75,16 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
         default: 'SELECT * FROM [Users] AS [User] LIMIT 10 OFFSET 5;',
         'mysql mariadb': 'SELECT * FROM `Users` AS `User` LIMIT 5, 10;',
         mssql: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[id] OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY;'
+      });
+    });
+
+    it('should generate SELECT query with ORDER BY', () => {
+      expectsql(User.select().orderBy(['name']).getQuery(), {
+        default: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[name];'
+      });
+
+      expectsql(User.select().orderBy([['age', 'DESC']]).getQuery(), {
+        default: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[age] DESC;'
       });
     });
   });

--- a/test/integration/query-builder.test.js
+++ b/test/integration/query-builder.test.js
@@ -341,7 +341,16 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
           .where({ age: { [Op.gt]: 30 } })
           .getQuery({ multiline: true }),
         {
-          default: 'SELECT [name], [email]\nFROM [Users] AS [User]\nWHERE [User].[age] > 30;'
+          default: [
+            'SELECT [name], [email]',
+            'FROM [Users] AS [User]',
+            'WHERE [User].[age] > 30;'
+          ].join('\n'),
+          oracle: [
+            'SELECT "name", "email"',
+            'FROM "Users" "User"',
+            'WHERE "User"."age" > 30;'
+          ].join('\n')
         }
       );
     });
@@ -415,7 +424,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
           {
             default: 'SELECT [User].*, [Posts].[id] AS [Posts.id], [Posts].[userId] AS [Posts.userId], [Posts].[title] AS [Posts.title], [Posts].[createdAt] AS [Posts.createdAt], [Posts].[updatedAt] AS [Posts.updatedAt] FROM [Users] AS [User] LEFT OUTER JOIN [Posts] AS [Posts] ON [User].[id] = [Posts].[userId] AND [Posts].[title] = \'Hello World\';',
             mssql: 'SELECT [User].*, [Posts].[id] AS [Posts.id], [Posts].[userId] AS [Posts.userId], [Posts].[title] AS [Posts.title], [Posts].[createdAt] AS [Posts.createdAt], [Posts].[updatedAt] AS [Posts.updatedAt] FROM [Users] AS [User] LEFT OUTER JOIN [Posts] AS [Posts] ON [User].[id] = [Posts].[userId] AND [Posts].[title] = N\'Hello World\';',
-            oracle: 'SELECT "User".*, "Posts"."id" AS "Posts.id", "Posts"."userId" AS "Posts.userId", "Posts"."title" AS "Posts.title", "Posts"."createdAt" AS "Posts.createdAt", "Posts"."updatedAt" AS "Posts.updatedAt" FROM "Users" "User" LEFT OUTER JOIN "Posts" "Posts" ON "User"."id" = "Posts"."userId" AND "Posts"."title" = \'Hello World\';"'
+            oracle: 'SELECT "User".*, "Posts"."id" AS "Posts.id", "Posts"."userId" AS "Posts.userId", "Posts"."title" AS "Posts.title", "Posts"."createdAt" AS "Posts.createdAt", "Posts"."updatedAt" AS "Posts.updatedAt" FROM "Users" "User" LEFT OUTER JOIN "Posts" "Posts" ON "User"."id" = "Posts"."userId" AND "Posts"."title" = \'Hello World\';'
           }
         );
       });
@@ -450,7 +459,18 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
             .where({ age: { [Op.gt]: 30 } })
             .getQuery({ multiline: true }),
           {
-            default: 'SELECT [User].[name], [Posts].[title] AS [Posts.title]\nFROM [Users] AS [User]\nLEFT OUTER JOIN [Posts] AS [Posts] ON [User].[id] = [Posts].[userId]\nWHERE [User].[age] > 30;'
+            default: [
+              'SELECT [User].[name], [Posts].[title] AS [Posts.title]',
+              'FROM [Users] AS [User]',
+              'LEFT OUTER JOIN [Posts] AS [Posts] ON [User].[id] = [Posts].[userId]',
+              'WHERE [User].[age] > 30;'
+            ].join('\n'),
+            oracle: [
+              'SELECT "User"."name", "Posts"."title" AS "Posts.title"',
+              'FROM "Users" "User"',
+              'LEFT OUTER JOIN "Posts" "Posts" ON "User"."id" = "Posts"."userId"',
+              'WHERE "User"."age" > 30;'
+            ].join('\n')
           }
         );
       });

--- a/test/integration/query-builder.test.js
+++ b/test/integration/query-builder.test.js
@@ -135,7 +135,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
     });
   });
 
-  if (['postgres', 'postgres-native'].includes(process.env.DIALECT)) {
+  if (Support.getTestDialect() === 'postgres') {
     describe('PostgreSQL-specific features', () => {
       it('should handle PostgreSQL operators correctly', () => {
         expectsql(

--- a/test/integration/query-builder.test.js
+++ b/test/integration/query-builder.test.js
@@ -220,6 +220,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
 
   describe('execute', () => {
     it('should execute the query', async () => {
+      await User.sync({ force: true });
       await User.create({ name: 'John', email: 'john@example.com', active: true });
       const result = await User.select()
         .attributes(['name'])

--- a/test/integration/query-builder.test.js
+++ b/test/integration/query-builder.test.js
@@ -124,7 +124,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
     });
   });
 
-  if (process.env.DIALECT?.startsWith('postgres')) {
+  if (['postgres', 'postgres-native'].includes(process.env.DIALECT)) {
     describe('PostgreSQL-specific features', () => {
       it('should handle PostgreSQL operators correctly', () => {
         expectsql(

--- a/test/integration/query-builder.test.js
+++ b/test/integration/query-builder.test.js
@@ -1,0 +1,232 @@
+const { DataTypes, Op } = require('../../src');
+const { expect } = require('chai');
+const QueryBuilder = require('../../src/query-builder');
+const Support = require('../support');
+
+const expectsql = Support.expectsql;
+
+describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
+  let User;
+  before(async function() {
+    User = this.sequelize.define('User', {
+      name: DataTypes.STRING,
+      age: DataTypes.INTEGER,
+      active: DataTypes.BOOLEAN
+    });
+    await User.sync({ force: true });
+    this.sequelize.options.quoteIdentifiers = true;
+    this.queryInterface = this.sequelize.getQueryInterface();
+  });
+  
+  after(async () => {
+    if (this.sequelize) {
+      await Support.dropTestSchemas(this.sequelize);
+      await this.sequelize.close();
+    }
+  });
+
+  describe('Basic QueryBuilder functionality', () => {
+    it('should generate basic SELECT query', () => {
+      expectsql(User.select().getQuery(), {
+        default: 'SELECT * FROM [Users] AS [User];'
+      });
+    });
+
+    it('should generate SELECT query with specific attributes', () => {
+      expectsql(User.select().attributes(['name', 'email']).getQuery(), {
+        default: 'SELECT [name], [email] FROM [Users] AS [User];'
+      });
+    });
+
+    it('should generate SELECT query with WHERE clause', () => {
+      expectsql(User.select().where({ active: true }).getQuery(), {
+        default: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = true;',
+        'mssql sqlite3': 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;'
+      });
+    });
+
+    it('should generate SELECT query with multiple WHERE conditions', () => {
+      expectsql(User.select().where({ active: true, age: 25 }).getQuery(), {
+        default: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = true AND [User].[age] = 25;',
+        'mssql sqlite3': 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1 AND [User].[age] = 25;'
+      });
+    });
+
+    it('should generate complete SELECT query with attributes and WHERE', () => {
+      expectsql(
+        User.select().attributes(['name', 'email']).where({ active: true }).getQuery(),
+        {
+          default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = true;',
+          'mssql sqlite3': 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;'
+        }
+      );
+    });
+
+    it('should generate SELECT query with LIMIT', () => {
+      expectsql(User.select().limit(10).getQuery(), {
+        default: 'SELECT * FROM [Users] AS [User] LIMIT 10;',
+        mssql: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[id] OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;'
+      });
+    });
+
+    it('should generate SELECT query with LIMIT and OFFSET', () => {
+      expectsql(User.select().limit(10).offset(5).getQuery(), {
+        default: 'SELECT * FROM [Users] AS [User] LIMIT 10 OFFSET 5;',
+        'mysql mariadb': 'SELECT * FROM `Users` AS `User` LIMIT 5, 10;',
+        mssql: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[id] OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY;'
+      });
+    });
+  });
+
+  describe('Functional/Immutable behavior', () => {
+    it('should return new instances for each method call', () => {
+      const builder1 = User.select();
+      const builder2 = builder1.attributes(['name']);
+      const builder3 = builder2.where({ active: true });
+
+      expect(builder1).to.not.equal(builder2);
+      expect(builder2).to.not.equal(builder3);
+      expect(builder1).to.not.equal(builder3);
+    });
+
+    it('should not mutate original builder when chaining', () => {
+      const baseBuilder = User.select();
+      const builderWithAttributes = baseBuilder.attributes(['name']);
+      const builderWithWhere = baseBuilder.where({ active: true });
+
+      // Base builder should remain unchanged
+      expectsql(baseBuilder.getQuery(), {
+        default: 'SELECT * FROM [Users] AS [User];'
+      });
+
+      // Other builders should have their modifications
+      expectsql(builderWithAttributes.getQuery(), {
+        default: 'SELECT [name] FROM [Users] AS [User];'
+      });
+
+      expectsql(builderWithWhere.getQuery(), {
+        default: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = true;',
+        'mssql sqlite3': 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;'
+      });
+    });
+
+    it('should allow building different queries from same base', () => {
+      const baseBuilder = User.select().attributes(['name', 'email']);
+
+      expectsql(baseBuilder.where({ active: true }).getQuery(), {
+        default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = true;',
+        'mssql sqlite3': 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;'
+      });
+
+      expectsql(baseBuilder.where({ age: { [Op.lt]: 30 } }).getQuery(), {
+        default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[age] < 30;'
+      });
+    });
+  });
+
+  if (process.env.DIALECT?.startsWith('postgres')) {
+    describe('PostgreSQL-specific features', () => {
+      it('should handle PostgreSQL operators correctly', () => {
+        expectsql(
+          User.select()
+            .where({
+              name: { [Op.iLike]: '%john%' },
+              age: { [Op.between]: [18, 65] }
+            })
+            .getQuery(),
+          {
+            default: 'SELECT * FROM [Users] AS [User] WHERE [User].[name] ILIKE \'%john%\' AND [User].[age] BETWEEN 18 AND 65;'
+          }
+        );
+      });
+
+      it('should handle array operations', () => {
+        expectsql(
+          User.select()
+            .where({
+              name: { [Op.in]: ['John', 'Jane', 'Bob'] }
+            })
+            .getQuery(),
+          {
+            default: 'SELECT * FROM [Users] AS [User] WHERE [User].[name] IN (\'John\', \'Jane\', \'Bob\');'
+          }
+        );
+      });
+
+      it('should quote identifiers properly for PostgreSQL', () => {
+        expectsql(
+          User.select().attributes(['name', 'email']).where({ active: true }).getQuery(),
+          {
+            default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = true;'
+          }
+        );
+      });
+    });
+  }
+
+  describe('Error handling', () => {
+    it('should throw error when getQuery is called on non-select builder', () => {
+      expect(() => {
+        const builder = new QueryBuilder(User);
+        builder.getQuery();
+      }).to.throw();
+    });
+
+    it('should handle empty attributes array', () => {
+      expect(() => {
+        User.select().attributes([]).getQuery();
+      }).to.throw(/Attempted a SELECT query for model 'User' as .* without selecting any columns/);
+    });
+  });
+
+  describe('Complex WHERE conditions', () => {
+    it('should handle complex nested conditions', () => {
+      expectsql(
+        User.select()
+          .where({
+            [Op.or]: [
+              { active: true },
+              {
+                [Op.and]: [{ age: { [Op.gte]: 18 } }, { name: { [Op.like]: '%admin%' } }]
+              }
+            ]
+          })
+          .getQuery(),
+        {
+          default: 'SELECT * FROM [Users] AS [User] WHERE ([User].[active] = true OR ([User].[age] >= 18 AND [User].[name] LIKE \'%admin%\'));',
+          sqlite3: 'SELECT * FROM `users` AS `User` WHERE `User`.`active` = 1 OR (`User`.`age` >= 18 AND `User`.`name` LIKE \'%admin%\');',
+          mssql: 'SELECT * FROM [Users] AS [User] WHERE ([User].[active] = 1 OR ([User].[age] >= 18 AND [User].[name] LIKE N\'%admin%\'));'
+        }
+      );
+    });
+
+    it('should handle IS NULL conditions', () => {
+      expectsql(User.select().where({ age: null }).getQuery(), {
+        default: 'SELECT * FROM [Users] AS [User] WHERE [User].[age] IS NULL;'
+      });
+    });
+
+    it('should handle NOT NULL conditions', () => {
+      expectsql(
+        User.select()
+          .where({ age: { [Op.ne]: null } })
+          .getQuery(),
+        {
+          default: 'SELECT * FROM [Users] AS [User] WHERE [User].[age] IS NOT NULL;'
+        }
+      );
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute the query', async () => {
+      await User.create({ name: 'John', email: 'john@example.com', active: true });
+      const result = await User.select()
+        .attributes(['name'])
+        .where({ active: true, name: 'John' })
+        .execute();
+      const [row] = result;
+      expect(row).to.deep.equal([{ name: 'John' }]);
+    });
+  });
+});

--- a/test/integration/query-builder.test.js
+++ b/test/integration/query-builder.test.js
@@ -29,13 +29,15 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
   describe('Basic QueryBuilder functionality', () => {
     it('should generate basic SELECT query', () => {
       expectsql(User.select().getQuery(), {
-        default: 'SELECT * FROM [Users] AS [User];'
+        default: 'SELECT * FROM [Users] AS [User];',
+        oracle: 'SELECT * FROM [Users] [User];'
       });
     });
 
     it('should generate SELECT query with specific attributes', () => {
       expectsql(User.select().attributes(['name', 'email']).getQuery(), {
-        default: 'SELECT [name], [email] FROM [Users] AS [User];'
+        default: 'SELECT [name], [email] FROM [Users] AS [User];',
+        oracle: 'SELECT [name], [email] FROM [Users] [User];'
       });
     });
 
@@ -43,7 +45,8 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
       expectsql(User.select().where({ active: true }).getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = true;',
         sqlite: 'SELECT * FROM `Users` AS `User` WHERE `User`.`active` = 1;',
-        mssql: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;'
+        mssql: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;',
+        oracle: 'SELECT * FROM [Users] [User] WHERE [User].[active] = 1;'
       });
     });
 
@@ -51,7 +54,8 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
       expectsql(User.select().where({ active: true, age: 25 }).getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = true AND [User].[age] = 25;',
         sqlite: 'SELECT * FROM `Users` AS `User` WHERE `User`.`active` = 1 AND `User`.`age` = 25;',
-        mssql: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1 AND [User].[age] = 25;'
+        mssql: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1 AND [User].[age] = 25;',
+        oracle: 'SELECT * FROM [Users] [User] WHERE [User].[active] = 1 AND [User].[age] = 25;'
       });
     });
 
@@ -61,7 +65,8 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
         {
           default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = true;',
           sqlite: 'SELECT `name`, `email` FROM `Users` AS `User` WHERE `User`.`active` = 1;',
-          mssql: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;'
+          mssql: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;',
+          oracle: 'SELECT [name], [email] FROM [Users] [User] WHERE [User].[active] = 1;'
         }
       );
     });
@@ -69,6 +74,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
     it('should generate SELECT query with LIMIT', () => {
       expectsql(User.select().limit(10).getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] LIMIT 10;',
+        oracle: 'SELECT * FROM [Users] [User] ORDER BY [User].[id] OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;',
         mssql: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[id] OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;'
       });
     });
@@ -77,17 +83,20 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
       expectsql(User.select().limit(10).offset(5).getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] LIMIT 10 OFFSET 5;',
         'mysql mariadb sqlite': 'SELECT * FROM `Users` AS `User` LIMIT 5, 10;',
-        mssql: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[id] OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY;'
+        mssql: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[id] OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY;',
+        oracle: 'SELECT * FROM [Users] [User] ORDER BY [User].[id] OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY;'
       });
     });
 
     it('should generate SELECT query with ORDER BY', () => {
       expectsql(User.select().orderBy(['name']).getQuery(), {
-        default: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[name];'
+        default: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[name];',
+        oracle: 'SELECT * FROM [Users] [User] ORDER BY [User].[name];'
       });
 
       expectsql(User.select().orderBy([['age', 'DESC']]).getQuery(), {
-        default: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[age] DESC;'
+        default: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[age] DESC;',
+        oracle: 'SELECT * FROM [Users] [User] ORDER BY [User].[age] DESC;'
       });
     });
   });
@@ -110,18 +119,21 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
 
       // Base builder should remain unchanged
       expectsql(baseBuilder.getQuery(), {
-        default: 'SELECT * FROM [Users] AS [User];'
+        default: 'SELECT * FROM [Users] AS [User];',
+        oracle: 'SELECT * FROM [Users] [User];'
       });
 
       // Other builders should have their modifications
       expectsql(builderWithAttributes.getQuery(), {
-        default: 'SELECT [name] FROM [Users] AS [User];'
+        default: 'SELECT [name] FROM [Users] AS [User];',
+        oracle: 'SELECT [name] FROM [Users] [User];'
       });
 
       expectsql(builderWithWhere.getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = true;',
         sqlite: 'SELECT * FROM `Users` AS `User` WHERE `User`.`active` = 1;',
-        mssql: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;'
+        mssql: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;',
+        oracle: 'SELECT * FROM [Users] [User] WHERE [User].[active] = 1;'
       });
     });
 
@@ -131,11 +143,13 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
       expectsql(baseBuilder.where({ active: true }).getQuery(), {
         default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = true;',
         sqlite: 'SELECT `name`, `email` FROM `Users` AS `User` WHERE `User`.`active` = 1;',
-        mssql: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;'
+        mssql: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;',
+        oracle: 'SELECT [name], [email] FROM [Users] [User] WHERE [User].[active] = 1;'
       });
 
       expectsql(baseBuilder.where({ age: { [Op.lt]: 30 } }).getQuery(), {
-        default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[age] < 30;'
+        default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[age] < 30;',
+        oracle: 'SELECT [name], [email] FROM [Users] [User] WHERE [User].[age] < 30;'
       });
     });
   });
@@ -211,14 +225,16 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
         {
           default: 'SELECT * FROM [Users] AS [User] WHERE ([User].[active] = true OR ([User].[age] >= 18 AND [User].[name] LIKE \'%admin%\'));',
           sqlite: 'SELECT * FROM `Users` AS `User` WHERE (`User`.`active` = 1 OR (`User`.`age` >= 18 AND `User`.`name` LIKE \'%admin%\'));',
-          mssql: 'SELECT * FROM [Users] AS [User] WHERE ([User].[active] = 1 OR ([User].[age] >= 18 AND [User].[name] LIKE N\'%admin%\'));'
+          mssql: 'SELECT * FROM [Users] AS [User] WHERE ([User].[active] = 1 OR ([User].[age] >= 18 AND [User].[name] LIKE N\'%admin%\'));',
+          oracle: 'SELECT * FROM [Users] [User] WHERE ([User].[active] = 1 OR ([User].[age] >= 18 AND [User].[name] LIKE N\'%admin%\'));'
         }
       );
     });
 
     it('should handle IS NULL conditions', () => {
       expectsql(User.select().where({ age: null }).getQuery(), {
-        default: 'SELECT * FROM [Users] AS [User] WHERE [User].[age] IS NULL;'
+        default: 'SELECT * FROM [Users] AS [User] WHERE [User].[age] IS NULL;',
+        oracle: 'SELECT * FROM [Users] [User] WHERE [User].[age] IS NULL;'
       });
     });
 
@@ -228,7 +244,8 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
           .where({ age: { [Op.ne]: null } })
           .getQuery(),
         {
-          default: 'SELECT * FROM [Users] AS [User] WHERE [User].[age] IS NOT NULL;'
+          default: 'SELECT * FROM [Users] AS [User] WHERE [User].[age] IS NOT NULL;',
+          oracle: 'SELECT * FROM [Users] [User] WHERE [User].[age] IS NOT NULL;'
         }
       );
     });

--- a/test/integration/query-builder.test.js
+++ b/test/integration/query-builder.test.js
@@ -49,19 +49,19 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
       it('should generate SELECT query with aliased attributes', () => {
         expectsql(User.select().attributes([['name', 'username'], 'email']).getQuery(), {
           default: 'SELECT [name] AS [username], [email] FROM [Users] AS [User];',
-          oracle: 'SELECT "name" "username", "email" FROM "Users" "User";'
+          oracle: 'SELECT "name" AS "username", "email" FROM "Users" "User";'
         });
       });
       
       it('should generate SELECT query with literal attributes', () => {
         expectsql(User.select().attributes([sequelize.literal('"User"."email" AS "personalEmail"')]).getQuery(), {
           default: 'SELECT "User"."email" AS "personalEmail" FROM [Users] AS [User];', // literal
-          oracle: 'SELECT "User"."email" AS "personalEmail" FROM "Users" AS "User";'
+          oracle: 'SELECT "User"."email" AS "personalEmail" FROM "Users" "User";'
         });
   
         expectsql(User.select().attributes([[sequelize.literal('"User"."email"'), 'personalEmail']]).getQuery(), {
           default: 'SELECT "User"."email" AS [personalEmail] FROM [Users] AS [User];',
-          oracle: 'SELECT "User"."email" "personalEmail" FROM "Users" "User";'
+          oracle: 'SELECT "User"."email" AS "personalEmail" FROM "Users" "User";'
         });
       });
     }
@@ -147,7 +147,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
           .orderBy([[2, 'DESC']])
           .getQuery(), {
           default: 'SELECT [name], MAX("age") AS [maxAge] FROM [Users] AS [User] GROUP BY [name] ORDER BY 2 DESC;',
-          oracle: 'SELECT "name", MAX("age") "maxAge" FROM "Users" "User" GROUP BY "name" ORDER BY 2 DESC;'
+          oracle: 'SELECT "name", MAX("age") AS "maxAge" FROM "Users" "User" GROUP BY "name" ORDER BY 2 DESC;'
         });
       });
 
@@ -159,7 +159,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
           .having(sequelize.literal('MAX("age") > 30'))
           .getQuery(), {
           default: 'SELECT [name], MAX("age") AS [maxAge] FROM [Users] AS [User] GROUP BY [name] HAVING (MAX("age") > 30);',
-          oracle: 'SELECT "name", MAX("age") "maxAge" FROM "Users" "User" GROUP BY "name" HAVING (MAX("age") > 30);'
+          oracle: 'SELECT "name", MAX("age") AS "maxAge" FROM "Users" "User" GROUP BY "name" HAVING (MAX("age") > 30);'
         });
 
         expectsql(User
@@ -170,7 +170,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
           .andHaving(sequelize.literal('COUNT(*) > 1'))
           .getQuery(), {
           default: 'SELECT [name], MAX("age") AS [maxAge] FROM [Users] AS [User] GROUP BY [name] HAVING (MAX("age") > 30 AND COUNT(*) > 1);',
-          oracle: 'SELECT "name", MAX("age") "maxAge" FROM "Users" "User" GROUP BY "name" HAVING (MAX("age") > 30 AND COUNT(*) > 1);'
+          oracle: 'SELECT "name", MAX("age") AS "maxAge" FROM "Users" "User" GROUP BY "name" HAVING (MAX("age") > 30 AND COUNT(*) > 1);'
         });
       });
     }
@@ -195,20 +195,20 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
       // Base builder should remain unchanged
       expectsql(baseBuilder.getQuery(), {
         default: 'SELECT * FROM [Users] AS [User];',
-        oracle: 'SELECT * FROM [Users] [User];'
+        oracle: 'SELECT * FROM "Users" "User";'
       });
 
       // Other builders should have their modifications
       expectsql(builderWithAttributes.getQuery(), {
         default: 'SELECT [name] FROM [Users] AS [User];',
-        oracle: 'SELECT [name] FROM [Users] [User];'
+        oracle: 'SELECT "name" FROM "Users" "User";'
       });
 
       expectsql(builderWithWhere.getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = true;',
         sqlite: 'SELECT * FROM `Users` AS `User` WHERE `User`.`active` = 1;',
         mssql: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;',
-        oracle: 'SELECT * FROM [Users] [User] WHERE [User].[active] = 1;'
+        oracle: 'SELECT * FROM "Users" "User" WHERE "User"."active" = \'1\';'
       });
     });
 
@@ -219,12 +219,12 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
         default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = true;',
         sqlite: 'SELECT `name`, `email` FROM `Users` AS `User` WHERE `User`.`active` = 1;',
         mssql: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;',
-        oracle: 'SELECT [name], [email] FROM [Users] [User] WHERE [User].[active] = 1;'
+        oracle: 'SELECT "name", "email" FROM "Users" "User" WHERE "User"."active" = \'1\';'
       });
 
       expectsql(baseBuilder.where({ age: { [Op.lt]: 30 } }).getQuery(), {
         default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[age] < 30;',
-        oracle: 'SELECT [name], [email] FROM [Users] [User] WHERE [User].[age] < 30;'
+        oracle: 'SELECT "name", "email" FROM "Users" "User" WHERE "User"."age" < 30;'
       });
     });
   });
@@ -301,7 +301,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
           default: 'SELECT * FROM [Users] AS [User] WHERE ([User].[active] = true OR ([User].[age] >= 18 AND [User].[name] LIKE \'%admin%\'));',
           sqlite: 'SELECT * FROM `Users` AS `User` WHERE (`User`.`active` = 1 OR (`User`.`age` >= 18 AND `User`.`name` LIKE \'%admin%\'));',
           mssql: 'SELECT * FROM [Users] AS [User] WHERE ([User].[active] = 1 OR ([User].[age] >= 18 AND [User].[name] LIKE N\'%admin%\'));',
-          oracle: 'SELECT * FROM [Users] [User] WHERE ([User].[active] = 1 OR ([User].[age] >= 18 AND [User].[name] LIKE N\'%admin%\'));'
+          oracle: 'SELECT * FROM "Users" "User" WHERE ("User"."active" = \'1\' OR ("User"."age" >= 18 AND "User"."name" LIKE N\'%admin%\'));'
         }
       );
     });
@@ -309,7 +309,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
     it('should handle IS NULL conditions', () => {
       expectsql(User.select().where({ age: null }).getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] WHERE [User].[age] IS NULL;',
-        oracle: 'SELECT * FROM [Users] [User] WHERE [User].[age] IS NULL;'
+        oracle: 'SELECT * FROM "Users" "User" WHERE "User"."age" IS NULL;'
       });
     });
 
@@ -320,7 +320,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
           .getQuery(),
         {
           default: 'SELECT * FROM [Users] AS [User] WHERE [User].[age] IS NOT NULL;',
-          oracle: 'SELECT * FROM [Users] [User] WHERE [User].[age] IS NOT NULL;'
+          oracle: 'SELECT * FROM "Users" "User" WHERE "User"."age" IS NOT NULL;'
         }
       );
     });

--- a/test/integration/query-builder.test.js
+++ b/test/integration/query-builder.test.js
@@ -42,14 +42,16 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
     it('should generate SELECT query with WHERE clause', () => {
       expectsql(User.select().where({ active: true }).getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = true;',
-        'mssql sqlite3': 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;'
+        sqlite: 'SELECT * FROM `Users` AS `User` WHERE `User`.`active` = 1;',
+        mssql: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;'
       });
     });
 
     it('should generate SELECT query with multiple WHERE conditions', () => {
       expectsql(User.select().where({ active: true, age: 25 }).getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = true AND [User].[age] = 25;',
-        'mssql sqlite3': 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1 AND [User].[age] = 25;'
+        sqlite: 'SELECT * FROM `Users` AS `User` WHERE `User`.`active` = 1 AND `User`.`age` = 25;',
+        mssql: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1 AND [User].[age] = 25;'
       });
     });
 
@@ -58,7 +60,8 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
         User.select().attributes(['name', 'email']).where({ active: true }).getQuery(),
         {
           default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = true;',
-          'mssql sqlite3': 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;'
+          sqlite: 'SELECT `name`, `email` FROM `Users` AS `User` WHERE `User`.`active` = 1;',
+          mssql: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;'
         }
       );
     });
@@ -73,7 +76,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
     it('should generate SELECT query with LIMIT and OFFSET', () => {
       expectsql(User.select().limit(10).offset(5).getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] LIMIT 10 OFFSET 5;',
-        'mysql mariadb': 'SELECT * FROM `Users` AS `User` LIMIT 5, 10;',
+        'mysql mariadb sqlite': 'SELECT * FROM `Users` AS `User` LIMIT 5, 10;',
         mssql: 'SELECT * FROM [Users] AS [User] ORDER BY [User].[id] OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY;'
       });
     });
@@ -117,7 +120,8 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
 
       expectsql(builderWithWhere.getQuery(), {
         default: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = true;',
-        'mssql sqlite3': 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;'
+        sqlite: 'SELECT * FROM `Users` AS `User` WHERE `User`.`active` = 1;',
+        mssql: 'SELECT * FROM [Users] AS [User] WHERE [User].[active] = 1;'
       });
     });
 
@@ -126,7 +130,8 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
 
       expectsql(baseBuilder.where({ active: true }).getQuery(), {
         default: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = true;',
-        'mssql sqlite3': 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;'
+        sqlite: 'SELECT `name`, `email` FROM `Users` AS `User` WHERE `User`.`active` = 1;',
+        mssql: 'SELECT [name], [email] FROM [Users] AS [User] WHERE [User].[active] = 1;'
       });
 
       expectsql(baseBuilder.where({ age: { [Op.lt]: 30 } }).getQuery(), {
@@ -205,7 +210,7 @@ describe(Support.getTestDialectTeaser('QueryBuilder'), () => {
           .getQuery(),
         {
           default: 'SELECT * FROM [Users] AS [User] WHERE ([User].[active] = true OR ([User].[age] >= 18 AND [User].[name] LIKE \'%admin%\'));',
-          sqlite3: 'SELECT * FROM `users` AS `User` WHERE `User`.`active` = 1 OR (`User`.`age` >= 18 AND `User`.`name` LIKE \'%admin%\');',
+          sqlite: 'SELECT * FROM `Users` AS `User` WHERE (`User`.`active` = 1 OR (`User`.`age` >= 18 AND `User`.`name` LIKE \'%admin%\'));',
           mssql: 'SELECT * FROM [Users] AS [User] WHERE ([User].[active] = 1 OR ([User].[age] >= 18 AND [User].[name] LIKE N\'%admin%\'));'
         }
       );


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

Adds a simple query builder to sequelize static models. Basic functionality:
- [X] `Model.select()` -> will instantiate the query builder for chaining
- [X] `.attributes(['a', 'b'])` -> select attributes
- [X] `.where({c: true, d: 1})` -> specify where conditions
- [X] `.getQuery()` -> return plain SQL
- [X] Add an `.execute()` method that will run the raw sql instead of returning it
- [X] Support `.limit()` and `.offset()`
- [X] Support `.orderBy([['a', 'DESC'], ['b', 'ASC']])`
- [X] Support `.groupBy(['a', 'b', 1, 2])`
- [X] Support `.having()`
- [X] Support `.andHaving()`
- [X] Support `.include()` with custom join logic

Future improvements/additions:
- [ ] Support returning the Model objects instead of raw result
- [ ] Support `.andWhere` using Sequelize.where(col, op, value), Sequelize.literal() and `WhereBrackets` as per [proposal](https://gist.github.com/ephys/078ee6a2eb31dc209f0de6cea95316e7#new-api)
- [ ] Support `.orWhere`, block simultaneous usage with `.andWhere`
- [ ] Allow QueryBuilder on right-hand side of where options as a subquery/literal (DynamicValues?)

